### PR TITLE
Add MCP prompts capability with configuration and persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,4 +36,5 @@ Always run `npm run lint` and `npm run format` before committing changes.
 - Main documentation: [README.md](./README.md)
 - Detailed examples: [docs/examples.md](./docs/examples.md)
 - Configuration options: [docs/configuration.md](./docs/configuration.md)
+- Prompt system: [docs/prompts.md](./docs/prompts.md)
 - Testing framework: [docs/testing.md](./docs/testing.md)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ npm install -g @mettamatt/code-reasoning
    Please analyze this code using sequential thinking to break down the solution step by step.
    ```
 
+1. Access ready-to-use prompts:
+
+   - Click the "+" icon in the Claude Desktop chat window
+   - Select "Code Reasoning Tool" from the available tools
+   - Choose a prompt template and fill in the required information
+   - Submit the form to add the prompt to your chat message
+   - Send the message to Claude
+
+See the [Prompts Guide](./docs/prompts.md) for details on using the prompt templates.
+
 ## Command Line Options
 
 - `--debug`: Enable detailed logging
@@ -69,6 +79,9 @@ npm install -g @mettamatt/code-reasoning
 - **Thought Revision**: Refine earlier reasoning as understanding improves
 - **Safety Limits**: Automatically stops after 20 thought steps to prevent loops
 - **Advanced Debugging**: Comprehensive logging system
+- **Ready-to-Use Prompts**: Pre-defined templates for common development tasks
+- **Value Persistence**: Remembers argument values between prompt uses
+- **Filesystem Integration**: Easy access to project files
 
 ## Documentation
 
@@ -76,6 +89,7 @@ Detailed documentation available in the docs directory:
 
 - [Usage Examples](./docs/examples.md): Examples of sequential thinking
 - [Configuration Guide](./docs/configuration.md): All configuration options
+- [Prompts Guide](./docs/prompts.md): Using and customizing prompts
 - [Publishing Guide](./docs/publishing.md): Version management and publishing
 - [Testing Framework](./docs/testing.md): Testing information
 

--- a/config/prompt_values.json
+++ b/config/prompt_values.json
@@ -1,0 +1,33 @@
+{
+  "global": {
+    "working_directory": "~/Sites/code-reasoning"
+  },
+  "prompts": {
+    "architecture-decision": {
+      "decision_context": "",
+      "constraints": "",
+      "options": ""
+    },
+    "bug-analysis": {
+      "bug_behavior": "",
+      "expected_behavior": "",
+      "affected_components": "",
+      "reproduction_steps": ""
+    },
+    "code-review": {
+      "code": "",
+      "requirements": "",
+      "language": ""
+    },
+    "feature-planning": {
+      "problem_statement": "",
+      "target_users": "",
+      "success_criteria": "",
+      "affected_components": ""
+    },
+    "refactoring-plan": {
+      "current_issues": "",
+      "goals": ""
+    }
+  }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ This document provides detailed information about all configuration options avai
   - [VS Code Integration](#vs-code-integration)
 - [Component Configuration](#component-configuration)
   - [Logging Configuration](#logging-configuration)
+  - [Prompt Configuration](#prompt-configuration)
   - [Testing Configuration](#testing-configuration)
     - [Integrated Test Runner](#integrated-test-runner)
     - [Prompt Evaluation System](#prompt-evaluation-system)
@@ -18,10 +19,11 @@ This document provides detailed information about all configuration options avai
 
 The Code-Reasoning MCP Server supports the following command-line options:
 
-| Option         | Description                                   | Default | Example                  |
-| -------------- | --------------------------------------------- | ------- | ------------------------ |
-| `--debug`      | Enable debug logging with more verbose output | `false` | `code-reasoning --debug` |
-| `--help`, `-h` | Show help information                         | -       | `code-reasoning --help`  |
+| Option         | Description                                   | Default  | Example                                       |
+| -------------- | --------------------------------------------- | -------- | --------------------------------------------- |
+| `--debug`      | Enable debug logging with more verbose output | `false`  | `code-reasoning --debug`                      |
+| `--help`, `-h` | Show help information                         | -        | `code-reasoning --help`                       |
+| `--config-dir` | Specify the configuration directory           | `config` | `code-reasoning --config-dir=/path/to/config` |
 
 ### Usage Examples
 
@@ -150,6 +152,66 @@ const SERVER_CONFIG: CodeReasoningConfig = {
 ```
 
 The `debug` flag is set based on the command-line argument passed to the server.
+
+### Prompt Configuration
+
+The Code-Reasoning MCP Server includes a prompt system with the following configuration options:
+
+#### Command-Line Options
+
+| Option                 | Description                           | Default     | Example                                                |
+| ---------------------- | ------------------------------------- | ----------- | ------------------------------------------------------ |
+| `--config-dir`         | Directory for configuration files     | `./config`  | `code-reasoning --config-dir=/path/to/config`          |
+| `--custom-prompts-dir` | Directory for custom prompt templates | `undefined` | `code-reasoning --custom-prompts-dir=/path/to/prompts` |
+
+#### SERVER_CONFIG Options
+
+The prompt configuration is controlled by the SERVER_CONFIG object in `src/server.ts`:
+
+```typescript
+export const SERVER_CONFIG: Readonly<CodeReasoningConfig> = Object.freeze({
+  // Existing config...
+
+  // Prompt config with defaults
+  promptsEnabled: true,
+  customPromptsDir: undefined, // No custom prompts directory by default
+  configDir: path.join(process.cwd(), 'config'), // Default config directory
+});
+```
+
+#### Prompt Value Persistence
+
+The server automatically stores prompt argument values in a JSON file to reduce repetitive data entry:
+
+- **Storage Location**: Values are stored in `[config_dir]/prompt_values.json`
+- **Global Values**: Some values like `working_directory` are shared across all prompts
+- **Prompt-Specific Values**: Other values are stored for each specific prompt
+
+The structure of the stored values file:
+
+```json
+{
+  "global": {
+    "working_directory": "/path/to/project"
+  },
+  "prompts": {
+    "architecture-decision": {
+      "decision_context": "Previous value",
+      "constraints": "Previous constraints",
+      "options": "Previous options"
+    }
+    // Other prompts...
+  }
+}
+```
+
+This system automatically:
+
+1. Stores values when prompts are used
+2. Retrieves values when prompts are applied
+3. Merges stored values with user-provided values (user input takes precedence)
+
+See the [Prompts Guide](./prompts.md) for more details on using the prompt templates.
 
 ### Testing Configuration
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,0 +1,177 @@
+# Code Reasoning MCP Server Prompts
+
+This document provides detailed information about the prompt system in the Code Reasoning MCP server, including available prompts, how to use them, and how the prompt value persistence works.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Available Prompts](#available-prompts)
+- [Using Prompts with Claude Desktop](#using-prompts-with-claude-desktop)
+- [Working Directory Integration](#working-directory-integration)
+- [Prompt Value Persistence](#prompt-value-persistence)
+- [Filesystem Integration](#filesystem-integration)
+- [Customizing Prompts](#customizing-prompts)
+
+## Overview
+
+The Code Reasoning MCP server includes a set of predefined prompts designed for various software development tasks. These prompts utilize the structured, step-by-step reasoning approach to help solve complex programming problems.
+
+Key features of the prompt system:
+
+- **Predefined Templates**: Ready-to-use prompts for common development tasks
+- **Persistent Values**: Argument values are saved between sessions to reduce repetitive entry
+- **Working Directory Support**: Automatic handling of your current project directory
+- **Filesystem Integration**: Easy access to files through filesystem MCP tools
+
+## Available Prompts
+
+The Code Reasoning MCP server includes the following predefined prompts:
+
+| Prompt Name             | Description                                                 | Key Arguments                                                                    |
+| ----------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `architecture-decision` | Framework for making and documenting architecture decisions | `decision_context`, `constraints`, `options`                                     |
+| `bug-analysis`          | Systematic approach to analyzing and fixing bugs            | `bug_behavior`, `expected_behavior`, `affected_components`, `reproduction_steps` |
+| `code-review`           | Comprehensive template for code review                      | `code`, `requirements`, `language`                                               |
+| `feature-planning`      | Structured approach to planning new feature implementation  | `problem_statement`, `target_users`, `success_criteria`, `affected_components`   |
+| `refactoring-plan`      | Structured approach to code refactoring                     | `current_issues`, `goals`                                                        |
+
+All prompts also support a `working_directory` parameter that specifies the path to your current project directory.
+
+## Using Prompts with Claude Desktop
+
+To use Code Reasoning prompts with Claude Desktop:
+
+1. **Access the Prompts Menu**:
+
+   - Click the "+" icon in the Claude Desktop chat window
+   - Select "Code Reasoning Tool" from the available tools
+
+2. **Select a Prompt**:
+
+   - Choose one of the available prompts from the list
+   - A dialog window will appear with fields for the prompt arguments
+
+3. **Fill in the Arguments**:
+
+   - Enter the required information in each field
+   - Include your working directory if needed (e.g., `~/projects/my-app`)
+
+4. **Submit the Prompt**:
+
+   - Click the submit button in the dialog
+   - The prompt with your variables will be attached to the chat message as a pasted file
+
+5. **Send the Message**:
+   - Click the send button to submit the prompt to Claude
+   - Claude will use the Code Reasoning tool to provide a structured analysis
+
+## Working Directory Integration
+
+All prompts support a `working_directory` parameter that allows you to specify your current project directory. This enables:
+
+- Clear context for Claude about your project location
+- Easy reference to project files and directories
+- Simplified file access through filesystem tools
+
+Example working directory values:
+
+- macOS/Linux: `~/projects/my-app` or `/Users/username/projects/my-app`
+- Windows: `C:\Users\username\projects\my-app`
+
+## Prompt Value Persistence
+
+The Code Reasoning MCP server now includes a feature to persist prompt argument values between sessions. This significantly reduces repetitive data entry.
+
+### How It Works
+
+1. **Value Storage**:
+
+   - When you use a prompt, the argument values are saved to a JSON file
+   - The file is stored in the `config/prompt_values.json` directory
+   - Values are organized by prompt name for easy retrieval
+
+2. **Global Values**:
+
+   - Some values like `working_directory` are stored globally
+   - These global values are shared across all prompts
+   - This means you only need to set your working directory once
+
+3. **Automatic Retrieval**:
+   - When you use a prompt again, saved values are automatically retrieved
+   - The fields in the prompt dialog will be pre-filled with the saved values
+   - You can always override saved values by entering new ones
+
+### Storage Location
+
+Prompt values are stored in:
+
+```
+[installation_directory]/config/prompt_values.json
+```
+
+If you want to reset stored values, you can simply delete this file or modify it directly.
+
+## Filesystem Integration
+
+All prompts include guidance for accessing and modifying files using filesystem tools. This allows Claude to:
+
+- Read files from your project
+- List directory contents
+- Search for specific files or code patterns
+- Make changes to files when needed
+
+To take advantage of this feature:
+
+1. Make sure your working directory is correctly set
+2. Use absolute paths when referencing files
+3. Ensure you have filesystem MCP tools available in your Claude Desktop configuration
+
+Typical filesystem operations Claude can perform:
+
+- `read_file("/path/to/file")`
+- `list_directory("/path/to/directory")`
+- `search_code("/path/to/directory", "search pattern")`
+- `edit_block("/path/to/file", "old_text", "new_text")`
+
+## Customizing Prompts
+
+You can customize the built-in prompts or create your own by adding JSON files to a custom prompts directory.
+
+### Custom Prompts Directory
+
+To use custom prompts:
+
+1. Set the `customPromptsDir` option in your configuration:
+
+   ```json
+   {
+     "mcpServers": {
+       "code-reasoning": {
+         "command": "npx",
+         "args": ["-y", "@mettamatt/code-reasoning", "--custom-prompts-dir=/path/to/prompts"]
+       }
+     }
+   }
+   ```
+
+2. Create JSON files in the specified directory with the following format:
+
+   ```json
+   {
+     "name": "custom-prompt-name",
+     "description": "Description of your custom prompt",
+     "arguments": [
+       {
+         "name": "arg_name",
+         "description": "Description of this argument",
+         "required": true
+       }
+       // Other arguments...
+     ],
+     "template": "# Custom Prompt Template\n\nWorking Directory: {working_directory}\n\nYour template text with {arg_name} placeholders..."
+   }
+   ```
+
+3. Restart the server to load your custom prompts
+
+Custom prompts will appear alongside the built-in ones in the Claude Desktop interface.

--- a/src/prompts/manager.ts
+++ b/src/prompts/manager.ts
@@ -1,0 +1,193 @@
+/**
+ * @fileoverview Prompt manager for MCP prompts.
+ *
+ * This class handles the management of prompts, including registration,
+ * validation, and application of prompt templates.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { Prompt, PromptResult } from './types.js';
+import { CODE_REASONING_PROMPTS, PROMPT_TEMPLATES } from './templates.js';
+
+/**
+ * Manages prompt templates and their operations.
+ */
+export class PromptManager {
+  private prompts: Record<string, Prompt>;
+  private templates: Record<string, (args: Record<string, string>) => PromptResult>;
+  
+  /**
+   * Creates a new PromptManager instance with default code reasoning prompts.
+   */
+  constructor() {
+    this.prompts = { ...CODE_REASONING_PROMPTS };
+    this.templates = { ...PROMPT_TEMPLATES };
+    console.error('PromptManager initialized with', Object.keys(this.prompts).length, 'prompts');
+  }
+  
+  /**
+   * Registers a new prompt and its template function.
+   * 
+   * @param prompt The prompt definition
+   * @param template The template function that applies arguments to generate a result
+   */
+  registerPrompt(
+    prompt: Prompt, 
+    template: (args: Record<string, string>) => PromptResult
+  ): void {
+    this.prompts[prompt.name] = prompt;
+    this.templates[prompt.name] = template;
+    console.error(`Registered prompt: ${prompt.name}`);
+  }
+  
+  /**
+   * Gets all available prompts.
+   * 
+   * @returns An array of all registered prompts
+   */
+  getAllPrompts(): Prompt[] {
+    return Object.values(this.prompts);
+  }
+  
+  /**
+   * Gets a specific prompt by name.
+   * 
+   * @param name The name of the prompt to retrieve
+   * @returns The prompt or undefined if not found
+   */
+  getPrompt(name: string): Prompt | undefined {
+    return this.prompts[name];
+  }
+  
+  /**
+   * Applies a prompt with the given arguments.
+   * 
+   * @param name The name of the prompt to apply
+   * @param args The arguments to apply to the prompt template
+   * @returns The result of applying the prompt
+   * @throws Error if the prompt doesn't exist or arguments are invalid
+   */
+  applyPrompt(name: string, args: Record<string, string> = {}): PromptResult {
+    const prompt = this.getPrompt(name);
+    if (!prompt) {
+      throw new Error(`Prompt not found: ${name}`);
+    }
+    
+    // Validate arguments
+    const validationErrors = this.validatePromptArguments(prompt, args);
+    if (validationErrors.length > 0) {
+      throw new Error(`Validation errors:\n${validationErrors.join('\n')}`);
+    }
+    
+    // Get the template function
+    const templateFn = this.templates[name];
+    if (!templateFn) {
+      throw new Error(`Template implementation not found for prompt: ${name}`);
+    }
+    
+    // Apply the template
+    return templateFn(args);
+  }
+  
+  /**
+   * Loads custom prompts from JSON files in a directory.
+   * 
+   * @param directory The directory containing JSON prompt files
+   */
+  async loadCustomPrompts(directory: string): Promise<void> {
+    try {
+      if (!fs.existsSync(directory)) {
+        console.error(`Custom prompts directory not found: ${directory}`);
+        return;
+      }
+      
+      const files = fs.readdirSync(directory);
+      console.error(`Found ${files.length} files in custom prompts directory`);
+      
+      for (const file of files) {
+        if (file.endsWith('.json')) {
+          try {
+            const filePath = path.join(directory, file);
+            const content = fs.readFileSync(filePath, 'utf8');
+            const promptData = JSON.parse(content);
+            
+            // Validate and register the prompt
+            if (promptData.name && promptData.description && promptData.template) {
+              this.registerPrompt(
+                {
+                  name: promptData.name,
+                  description: promptData.description,
+                  arguments: promptData.arguments || [],
+                },
+                (args) => ({
+                  messages: [{
+                    role: 'user',
+                    content: {
+                      type: 'text',
+                      text: this.applyTemplate(promptData.template, args),
+                    },
+                  }],
+                })
+              );
+              console.error(`Loaded custom prompt: ${promptData.name}`);
+            } else {
+              console.error(`Invalid prompt in file ${file}: missing required fields`);
+            }
+          } catch (err) {
+            console.error(`Error loading prompt from ${file}:`, err);
+          }
+        }
+      }
+    } catch (err) {
+      console.error(`Error loading custom prompts:`, err);
+    }
+  }
+  
+  /**
+   * Validates prompt arguments against the prompt definition.
+   * 
+   * @param prompt The prompt to validate against
+   * @param args The arguments to validate
+   * @returns Array of validation error messages, empty if valid
+   */
+  private validatePromptArguments(prompt: Prompt, args: Record<string, string>): string[] {
+    const errors: string[] = [];
+    
+    // Check for required arguments
+    (prompt.arguments || []).forEach((arg: { name: string; description: string; required: boolean }) => {
+      if (arg.required && (!args[arg.name] || args[arg.name].trim() === '')) {
+        errors.push(`Missing required argument: ${arg.name} (${arg.description})`);
+      }
+    });
+    
+    // Check for unknown arguments
+    const validArgNames = new Set((prompt.arguments || []).map(arg => arg.name));
+    Object.keys(args).forEach(argName => {
+      if (!validArgNames.has(argName)) {
+        errors.push(`Unknown argument: ${argName}`);
+      }
+    });
+    
+    return errors;
+  }
+  
+  /**
+   * Applies a template string with argument values.
+   * 
+   * @param template The template string
+   * @param args The argument values to apply
+   * @returns The template with arguments applied
+   */
+  private applyTemplate(template: string, args: Record<string, string>): string {
+    let result = template;
+    
+    // Replace {arg_name} with values
+    Object.entries(args).forEach(([key, value]: [string, string]) => {
+      const regex = new RegExp(`\\{${key}\\}`, 'g');
+      result = result.replace(regex, value || '');
+    });
+    
+    return result;
+  }
+}

--- a/src/prompts/manager.ts
+++ b/src/prompts/manager.ts
@@ -16,7 +16,7 @@ import { CODE_REASONING_PROMPTS, PROMPT_TEMPLATES } from './templates.js';
 export class PromptManager {
   private prompts: Record<string, Prompt>;
   private templates: Record<string, (args: Record<string, string>) => PromptResult>;
-  
+
   /**
    * Creates a new PromptManager instance with default code reasoning prompts.
    */
@@ -25,44 +25,41 @@ export class PromptManager {
     this.templates = { ...PROMPT_TEMPLATES };
     console.error('PromptManager initialized with', Object.keys(this.prompts).length, 'prompts');
   }
-  
+
   /**
    * Registers a new prompt and its template function.
-   * 
+   *
    * @param prompt The prompt definition
    * @param template The template function that applies arguments to generate a result
    */
-  registerPrompt(
-    prompt: Prompt, 
-    template: (args: Record<string, string>) => PromptResult
-  ): void {
+  registerPrompt(prompt: Prompt, template: (args: Record<string, string>) => PromptResult): void {
     this.prompts[prompt.name] = prompt;
     this.templates[prompt.name] = template;
     console.error(`Registered prompt: ${prompt.name}`);
   }
-  
+
   /**
    * Gets all available prompts.
-   * 
+   *
    * @returns An array of all registered prompts
    */
   getAllPrompts(): Prompt[] {
     return Object.values(this.prompts);
   }
-  
+
   /**
    * Gets a specific prompt by name.
-   * 
+   *
    * @param name The name of the prompt to retrieve
    * @returns The prompt or undefined if not found
    */
   getPrompt(name: string): Prompt | undefined {
     return this.prompts[name];
   }
-  
+
   /**
    * Applies a prompt with the given arguments.
-   * 
+   *
    * @param name The name of the prompt to apply
    * @param args The arguments to apply to the prompt template
    * @returns The result of applying the prompt
@@ -73,26 +70,26 @@ export class PromptManager {
     if (!prompt) {
       throw new Error(`Prompt not found: ${name}`);
     }
-    
+
     // Validate arguments
     const validationErrors = this.validatePromptArguments(prompt, args);
     if (validationErrors.length > 0) {
       throw new Error(`Validation errors:\n${validationErrors.join('\n')}`);
     }
-    
+
     // Get the template function
     const templateFn = this.templates[name];
     if (!templateFn) {
       throw new Error(`Template implementation not found for prompt: ${name}`);
     }
-    
+
     // Apply the template
     return templateFn(args);
   }
-  
+
   /**
    * Loads custom prompts from JSON files in a directory.
-   * 
+   *
    * @param directory The directory containing JSON prompt files
    */
   async loadCustomPrompts(directory: string): Promise<void> {
@@ -101,17 +98,17 @@ export class PromptManager {
         console.error(`Custom prompts directory not found: ${directory}`);
         return;
       }
-      
+
       const files = fs.readdirSync(directory);
       console.error(`Found ${files.length} files in custom prompts directory`);
-      
+
       for (const file of files) {
         if (file.endsWith('.json')) {
           try {
             const filePath = path.join(directory, file);
             const content = fs.readFileSync(filePath, 'utf8');
             const promptData = JSON.parse(content);
-            
+
             // Validate and register the prompt
             if (promptData.name && promptData.description && promptData.template) {
               this.registerPrompt(
@@ -120,14 +117,16 @@ export class PromptManager {
                   description: promptData.description,
                   arguments: promptData.arguments || [],
                 },
-                (args) => ({
-                  messages: [{
-                    role: 'user',
-                    content: {
-                      type: 'text',
-                      text: this.applyTemplate(promptData.template, args),
+                args => ({
+                  messages: [
+                    {
+                      role: 'user',
+                      content: {
+                        type: 'text',
+                        text: this.applyTemplate(promptData.template, args),
+                      },
                     },
-                  }],
+                  ],
                 })
               );
               console.error(`Loaded custom prompt: ${promptData.name}`);
@@ -143,24 +142,26 @@ export class PromptManager {
       console.error(`Error loading custom prompts:`, err);
     }
   }
-  
+
   /**
    * Validates prompt arguments against the prompt definition.
-   * 
+   *
    * @param prompt The prompt to validate against
    * @param args The arguments to validate
    * @returns Array of validation error messages, empty if valid
    */
   private validatePromptArguments(prompt: Prompt, args: Record<string, string>): string[] {
     const errors: string[] = [];
-    
+
     // Check for required arguments
-    (prompt.arguments || []).forEach((arg: { name: string; description: string; required: boolean }) => {
-      if (arg.required && (!args[arg.name] || args[arg.name].trim() === '')) {
-        errors.push(`Missing required argument: ${arg.name} (${arg.description})`);
+    (prompt.arguments || []).forEach(
+      (arg: { name: string; description: string; required: boolean }) => {
+        if (arg.required && (!args[arg.name] || args[arg.name].trim() === '')) {
+          errors.push(`Missing required argument: ${arg.name} (${arg.description})`);
+        }
       }
-    });
-    
+    );
+
     // Check for unknown arguments
     const validArgNames = new Set((prompt.arguments || []).map(arg => arg.name));
     Object.keys(args).forEach(argName => {
@@ -168,26 +169,26 @@ export class PromptManager {
         errors.push(`Unknown argument: ${argName}`);
       }
     });
-    
+
     return errors;
   }
-  
+
   /**
    * Applies a template string with argument values.
-   * 
+   *
    * @param template The template string
    * @param args The argument values to apply
    * @returns The template with arguments applied
    */
   private applyTemplate(template: string, args: Record<string, string>): string {
     let result = template;
-    
+
     // Replace {arg_name} with values
     Object.entries(args).forEach(([key, value]: [string, string]) => {
       const regex = new RegExp(`\\{${key}\\}`, 'g');
       result = result.replace(regex, value || '');
     });
-    
+
     return result;
   }
 }

--- a/src/prompts/manager.ts
+++ b/src/prompts/manager.ts
@@ -7,9 +7,11 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { Prompt, PromptResult } from './types.js';
 import { CODE_REASONING_PROMPTS, PROMPT_TEMPLATES } from './templates.js';
 import { PromptValueManager } from './valueManager.js';
+import { expandTildePath } from '../utils/paths.js';
 
 /**
  * Manages prompt templates and their operations.
@@ -22,14 +24,23 @@ export class PromptManager {
   /**
    * Creates a new PromptManager instance with default code reasoning prompts.
    *
-   * @param configDir Optional directory for configuration files. Defaults to 'config' in the current working directory.
+   * @param configDir Optional directory for configuration files. Defaults to 'config' relative to the application directory.
    */
   constructor(configDir?: string) {
     this.prompts = { ...CODE_REASONING_PROMPTS };
     this.templates = { ...PROMPT_TEMPLATES };
 
+    // Get the current file's directory path
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
     // Initialize value manager with config directory
-    const resolvedConfigDir = configDir || path.join(process.cwd(), 'config');
+    // If configDir is provided, expand any tilde characters
+    // Otherwise use a directory relative to the application
+    const resolvedConfigDir = configDir
+      ? expandTildePath(configDir)
+      : path.join(__dirname, '..', '..', 'config');
+
+    console.error(`Using config directory: ${resolvedConfigDir}`);
 
     // Create config directory if it doesn't exist
     if (!fs.existsSync(resolvedConfigDir)) {

--- a/src/prompts/templates.ts
+++ b/src/prompts/templates.ts
@@ -30,6 +30,11 @@ export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
         description: 'Options being considered',
         required: false,
       },
+      {
+        name: 'working_directory',
+        description: 'Path to the current project directory',
+        required: false,
+      },
     ],
   },
   'bug-analysis': {
@@ -56,6 +61,11 @@ export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
         description: 'Steps to reproduce the bug',
         required: false,
       },
+      {
+        name: 'working_directory',
+        description: 'Path to the current project directory',
+        required: false,
+      },
     ],
   },
   'code-review': {
@@ -75,6 +85,11 @@ export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
       {
         name: 'language',
         description: 'Programming language of the code',
+        required: false,
+      },
+      {
+        name: 'working_directory',
+        description: 'Path to the current project directory',
         required: false,
       },
     ],
@@ -103,6 +118,11 @@ export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
         description: 'Existing components that will need modification',
         required: false,
       },
+      {
+        name: 'working_directory',
+        description: 'Path to the current project directory',
+        required: false,
+      },
     ],
   },
   'refactoring-plan': {
@@ -118,6 +138,11 @@ export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
         name: 'goals',
         description: 'Goals of the refactoring effort',
         required: true,
+      },
+      {
+        name: 'working_directory',
+        description: 'Path to the current project directory',
+        required: false,
       },
     ],
   },
@@ -136,7 +161,11 @@ export const PROMPT_TEMPLATES: Record<string, (args: Record<string, string>) => 
           type: 'text',
           text: `# Architecture Decision Record
 
+${args.working_directory ? `Working Directory: ${args.working_directory}\n` : ''}
+
 Please use reflective problem-solving through sequential thinking to analyze this architectural decision. Use the code-reasoning mcp tool to break down your analysis into structured steps.
+
+Note: You can access and modify files using the filesystem tool mcp.
 
 1. **Context**
    - Decision context: ${args.decision_context || 'N/A'}
@@ -182,7 +211,11 @@ This critical architectural decision deserves thorough analysis. Use the code-re
           type: 'text',
           text: `# Bug Analysis Process
 
+${args.working_directory ? `Working Directory: ${args.working_directory}\n` : ''}
+
 Please use reflective problem-solving through sequential thinking to analyze this bug thoroughly. Use the code-reasoning mcp tool to break down your analysis into structured steps.
+
+Note: You can access and modify files using the filesystem tool mcp.
 
 1. **Understand the reported behavior**
    - Bug behavior: ${args.bug_behavior || 'N/A'}
@@ -219,7 +252,11 @@ Remember to use the code-reasoning mcp tool to structure your thinking through t
           type: 'text',
           text: `# Code Review Template
 
+${args.working_directory ? `Working Directory: ${args.working_directory}\n` : ''}
+
 Please use reflective problem-solving through sequential thinking to perform this code review. Use the code-reasoning mcp tool to break down your analysis into structured steps.
+
+Note: You can access and modify files using the filesystem tool mcp.
 
 1. **Code to Review**
 \`\`\`${args.language || ''}
@@ -273,7 +310,11 @@ For this complex code analysis, use the code-reasoning mcp tool to structure you
           type: 'text',
           text: `# Feature Planning Process
 
+${args.working_directory ? `Working Directory: ${args.working_directory}\n` : ''}
+
 Please use reflective problem-solving through sequential thinking to develop this feature plan. Use the code-reasoning mcp tool to break down your planning process into structured steps.
+
+Note: You can access and modify files using the filesystem tool mcp.
 
 1. **Feature Requirements**
    - Problem statement: ${args.problem_statement || 'N/A'}
@@ -318,7 +359,11 @@ This complex planning task will benefit from using the code-reasoning mcp tool t
           type: 'text',
           text: `# Refactoring Plan
 
+${args.working_directory ? `Working Directory: ${args.working_directory}\n` : ''}
+
 Please use reflective problem-solving through sequential thinking to develop this refactoring plan. Use the code-reasoning mcp tool to break down your analysis into structured steps.
+
+Note: You can access and modify files using the filesystem tool mcp.
 
 1. **Current Code Assessment**
    - Current issues: ${args.current_issues || 'N/A'}

--- a/src/prompts/templates.ts
+++ b/src/prompts/templates.ts
@@ -128,7 +128,7 @@ export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
  * Each function takes a record of argument values and returns a prompt result.
  */
 export const PROMPT_TEMPLATES: Record<string, (args: Record<string, string>) => PromptResult> = {
-  'bug-analysis': (args) => ({
+  'bug-analysis': args => ({
     messages: [
       {
         role: 'user',
@@ -161,7 +161,7 @@ export const PROMPT_TEMPLATES: Record<string, (args: Record<string, string>) => 
       },
     ],
   }),
-  'feature-planning': (args) => ({
+  'feature-planning': args => ({
     messages: [
       {
         role: 'user',
@@ -202,7 +202,7 @@ export const PROMPT_TEMPLATES: Record<string, (args: Record<string, string>) => 
       },
     ],
   }),
-  'code-review': (args) => ({
+  'code-review': args => ({
     messages: [
       {
         role: 'user',
@@ -252,7 +252,7 @@ ${args.requirements || 'No specific requirements provided.'}
       },
     ],
   }),
-  'refactoring-plan': (args) => ({
+  'refactoring-plan': args => ({
     messages: [
       {
         role: 'user',
@@ -293,7 +293,7 @@ ${args.requirements || 'No specific requirements provided.'}
       },
     ],
   }),
-  'architecture-decision': (args) => ({
+  'architecture-decision': args => ({
     messages: [
       {
         role: 'user',

--- a/src/prompts/templates.ts
+++ b/src/prompts/templates.ts
@@ -11,6 +11,27 @@ import { Prompt, PromptResult } from './types.js';
  * Collection of code reasoning prompts.
  */
 export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
+  'architecture-decision': {
+    name: 'architecture-decision',
+    description: 'Framework for making and documenting architecture decisions',
+    arguments: [
+      {
+        name: 'decision_context',
+        description: 'The architectural decision that needs to be made',
+        required: true,
+      },
+      {
+        name: 'constraints',
+        description: 'Constraints that impact the decision',
+        required: false,
+      },
+      {
+        name: 'options',
+        description: 'Options being considered',
+        required: false,
+      },
+    ],
+  },
   'bug-analysis': {
     name: 'bug-analysis',
     description: 'Systematic approach to analyzing and fixing bugs',
@@ -33,6 +54,27 @@ export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
       {
         name: 'reproduction_steps',
         description: 'Steps to reproduce the bug',
+        required: false,
+      },
+    ],
+  },
+  'code-review': {
+    name: 'code-review',
+    description: 'Comprehensive template for code review',
+    arguments: [
+      {
+        name: 'code',
+        description: 'Code to be reviewed',
+        required: true,
+      },
+      {
+        name: 'requirements',
+        description: 'Requirements that the code should implement',
+        required: false,
+      },
+      {
+        name: 'language',
+        description: 'Programming language of the code',
         required: false,
       },
     ],
@@ -63,27 +105,6 @@ export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
       },
     ],
   },
-  'code-review': {
-    name: 'code-review',
-    description: 'Comprehensive template for code review',
-    arguments: [
-      {
-        name: 'code',
-        description: 'Code to be reviewed',
-        required: true,
-      },
-      {
-        name: 'requirements',
-        description: 'Requirements that the code should implement',
-        required: false,
-      },
-      {
-        name: 'language',
-        description: 'Programming language of the code',
-        required: false,
-      },
-    ],
-  },
   'refactoring-plan': {
     name: 'refactoring-plan',
     description: 'Structured approach to code refactoring',
@@ -100,27 +121,6 @@ export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
       },
     ],
   },
-  'architecture-decision': {
-    name: 'architecture-decision',
-    description: 'Framework for making and documenting architecture decisions',
-    arguments: [
-      {
-        name: 'decision_context',
-        description: 'The architectural decision that needs to be made',
-        required: true,
-      },
-      {
-        name: 'constraints',
-        description: 'Constraints that impact the decision',
-        required: false,
-      },
-      {
-        name: 'options',
-        description: 'Options being considered',
-        required: false,
-      },
-    ],
-  },
 };
 
 /**
@@ -128,6 +128,52 @@ export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
  * Each function takes a record of argument values and returns a prompt result.
  */
 export const PROMPT_TEMPLATES: Record<string, (args: Record<string, string>) => PromptResult> = {
+  'architecture-decision': args => ({
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `# Architecture Decision Record
+
+Please use reflective problem-solving through sequential thinking to analyze this architectural decision. Use the code-reasoning mcp tool to break down your analysis into structured steps.
+
+1. **Context**
+   - Decision context: ${args.decision_context || 'N/A'}
+   - Constraints: ${args.constraints || 'N/A'}
+   - Options: ${args.options || 'N/A'}
+
+2. **Options Considered**
+   - What alternatives have we identified?
+   - For each alternative:
+     - What are its key characteristics?
+     - What are its advantages?
+     - What are its disadvantages?
+     - What risks does it present?
+
+3. **Decision Criteria**
+   - What factors are most important for this decision?
+   - How do we weigh different concerns (performance, maintainability, etc.)?
+
+4. **Evaluation**
+   - How does each option perform against our criteria?
+   - What trade-offs does each option represent?
+
+5. **Decision**
+   - Which option do we select and why?
+   - What were the key factors in this decision?
+
+6. **Consequences**
+   - What are the implications of this decision?
+   - What becomes easier or harder as a result?
+   - What new constraints does this create?
+   - What follow-up decisions will be needed?
+
+This critical architectural decision deserves thorough analysis. Use the code-reasoning mcp tool to structure your thinking and explore different perspectives step by step.`,
+        },
+      },
+    ],
+  }),
   'bug-analysis': args => ({
     messages: [
       {
@@ -135,6 +181,8 @@ export const PROMPT_TEMPLATES: Record<string, (args: Record<string, string>) => 
         content: {
           type: 'text',
           text: `# Bug Analysis Process
+
+Please use reflective problem-solving through sequential thinking to analyze this bug thoroughly. Use the code-reasoning mcp tool to break down your analysis into structured steps.
 
 1. **Understand the reported behavior**
    - Bug behavior: ${args.bug_behavior || 'N/A'}
@@ -156,48 +204,9 @@ export const PROMPT_TEMPLATES: Record<string, (args: Record<string, string>) => 
 6. **Propose fix**
    - Once cause is identified, what's the recommended fix?
    - What side effects might this fix have?
-   - How can we verify the fix works?`,
-        },
-      },
-    ],
-  }),
-  'feature-planning': args => ({
-    messages: [
-      {
-        role: 'user',
-        content: {
-          type: 'text',
-          text: `# Feature Planning Process
+   - How can we verify the fix works?
 
-1. **Feature Requirements**
-   - Problem statement: ${args.problem_statement || 'N/A'}
-   - Target users: ${args.target_users || 'N/A'}
-   - Success criteria: ${args.success_criteria || 'N/A'}
-
-2. **Architectural Considerations**
-   - Affected components: ${args.affected_components || 'N/A'}
-   - What new components might be needed?
-   - Are there any API changes required?
-
-3. **Implementation Strategy**
-   - Break down the feature into implementation tasks
-   - Identify dependencies between tasks
-   - Estimate complexity and effort
-   - Plan an implementation sequence
-
-4. **Testing Strategy**
-   - What unit tests will be needed?
-   - What integration tests will be needed?
-   - How will we validate user requirements are met?
-
-5. **Risks and Mitigations**
-   - What technical risks exist?
-   - What product/user risks exist?
-   - How can we mitigate each risk?
-
-6. **Acceptance Criteria**
-   - Define clear criteria for when this feature is complete
-   - Include performance and quality expectations`,
+Remember to use the code-reasoning mcp tool to structure your thinking through this complex debugging task.`,
         },
       },
     ],
@@ -209,6 +218,8 @@ export const PROMPT_TEMPLATES: Record<string, (args: Record<string, string>) => 
         content: {
           type: 'text',
           text: `# Code Review Template
+
+Please use reflective problem-solving through sequential thinking to perform this code review. Use the code-reasoning mcp tool to break down your analysis into structured steps.
 
 1. **Code to Review**
 \`\`\`${args.language || ''}
@@ -247,7 +258,54 @@ ${args.requirements || 'No specific requirements provided.'}
 8. **Summary and Recommendations**
    - Overall assessment
    - Key issues to address (prioritized)
-   - Suggestions for improvement`,
+   - Suggestions for improvement
+
+For this complex code analysis, use the code-reasoning mcp tool to structure your thinking and document your review process step by step.`,
+        },
+      },
+    ],
+  }),
+  'feature-planning': args => ({
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `# Feature Planning Process
+
+Please use reflective problem-solving through sequential thinking to develop this feature plan. Use the code-reasoning mcp tool to break down your planning process into structured steps.
+
+1. **Feature Requirements**
+   - Problem statement: ${args.problem_statement || 'N/A'}
+   - Target users: ${args.target_users || 'N/A'}
+   - Success criteria: ${args.success_criteria || 'N/A'}
+
+2. **Architectural Considerations**
+   - Affected components: ${args.affected_components || 'N/A'}
+   - What new components might be needed?
+   - Are there any API changes required?
+
+3. **Implementation Strategy**
+   - Break down the feature into implementation tasks
+   - Identify dependencies between tasks
+   - Estimate complexity and effort
+   - Plan an implementation sequence
+
+4. **Testing Strategy**
+   - What unit tests will be needed?
+   - What integration tests will be needed?
+   - How will we validate user requirements are met?
+
+5. **Risks and Mitigations**
+   - What technical risks exist?
+   - What product/user risks exist?
+   - How can we mitigate each risk?
+
+6. **Acceptance Criteria**
+   - Define clear criteria for when this feature is complete
+   - Include performance and quality expectations
+
+This complex planning task will benefit from using the code-reasoning mcp tool to structure your thinking process.`,
         },
       },
     ],
@@ -259,6 +317,8 @@ ${args.requirements || 'No specific requirements provided.'}
         content: {
           type: 'text',
           text: `# Refactoring Plan
+
+Please use reflective problem-solving through sequential thinking to develop this refactoring plan. Use the code-reasoning mcp tool to break down your analysis into structured steps.
 
 1. **Current Code Assessment**
    - Current issues: ${args.current_issues || 'N/A'}
@@ -288,49 +348,9 @@ ${args.requirements || 'No specific requirements provided.'}
 6. **Implementation Plan**
    - Sequence of changes
    - Estimated effort
-   - Verification points`,
-        },
-      },
-    ],
-  }),
-  'architecture-decision': args => ({
-    messages: [
-      {
-        role: 'user',
-        content: {
-          type: 'text',
-          text: `# Architecture Decision Record
+   - Verification points
 
-1. **Context**
-   - Decision context: ${args.decision_context || 'N/A'}
-   - Constraints: ${args.constraints || 'N/A'}
-   - Options: ${args.options || 'N/A'}
-
-2. **Options Considered**
-   - What alternatives have we identified?
-   - For each alternative:
-     - What are its key characteristics?
-     - What are its advantages?
-     - What are its disadvantages?
-     - What risks does it present?
-
-3. **Decision Criteria**
-   - What factors are most important for this decision?
-   - How do we weigh different concerns (performance, maintainability, etc.)?
-
-4. **Evaluation**
-   - How does each option perform against our criteria?
-   - What trade-offs does each option represent?
-
-5. **Decision**
-   - Which option do we select and why?
-   - What were the key factors in this decision?
-
-6. **Consequences**
-   - What are the implications of this decision?
-   - What becomes easier or harder as a result?
-   - What new constraints does this create?
-   - What follow-up decisions will be needed?`,
+This complex refactoring task requires careful analysis. Use the code-reasoning mcp tool to structure your thought process for developing a safe and effective approach.`,
         },
       },
     ],

--- a/src/prompts/templates.ts
+++ b/src/prompts/templates.ts
@@ -1,0 +1,338 @@
+/**
+ * @fileoverview Prompt templates for code reasoning.
+ *
+ * This file defines a set of prompt templates specifically designed for
+ * code reasoning tasks.
+ */
+
+import { Prompt, PromptResult } from './types.js';
+
+/**
+ * Collection of code reasoning prompts.
+ */
+export const CODE_REASONING_PROMPTS: Record<string, Prompt> = {
+  'bug-analysis': {
+    name: 'bug-analysis',
+    description: 'Systematic approach to analyzing and fixing bugs',
+    arguments: [
+      {
+        name: 'bug_behavior',
+        description: 'Description of the observed bug behavior',
+        required: true,
+      },
+      {
+        name: 'expected_behavior',
+        description: 'What should happen when working correctly',
+        required: true,
+      },
+      {
+        name: 'affected_components',
+        description: 'Primary components affected by the bug',
+        required: true,
+      },
+      {
+        name: 'reproduction_steps',
+        description: 'Steps to reproduce the bug',
+        required: false,
+      },
+    ],
+  },
+  'feature-planning': {
+    name: 'feature-planning',
+    description: 'Structured approach to planning new feature implementation',
+    arguments: [
+      {
+        name: 'problem_statement',
+        description: 'Clear statement of the problem this feature solves',
+        required: true,
+      },
+      {
+        name: 'target_users',
+        description: 'Primary users who will benefit from this feature',
+        required: true,
+      },
+      {
+        name: 'success_criteria',
+        description: 'How we will know the feature is successful',
+        required: false,
+      },
+      {
+        name: 'affected_components',
+        description: 'Existing components that will need modification',
+        required: false,
+      },
+    ],
+  },
+  'code-review': {
+    name: 'code-review',
+    description: 'Comprehensive template for code review',
+    arguments: [
+      {
+        name: 'code',
+        description: 'Code to be reviewed',
+        required: true,
+      },
+      {
+        name: 'requirements',
+        description: 'Requirements that the code should implement',
+        required: false,
+      },
+      {
+        name: 'language',
+        description: 'Programming language of the code',
+        required: false,
+      },
+    ],
+  },
+  'refactoring-plan': {
+    name: 'refactoring-plan',
+    description: 'Structured approach to code refactoring',
+    arguments: [
+      {
+        name: 'current_issues',
+        description: 'Issues in the current code that prompted refactoring',
+        required: true,
+      },
+      {
+        name: 'goals',
+        description: 'Goals of the refactoring effort',
+        required: true,
+      },
+    ],
+  },
+  'architecture-decision': {
+    name: 'architecture-decision',
+    description: 'Framework for making and documenting architecture decisions',
+    arguments: [
+      {
+        name: 'decision_context',
+        description: 'The architectural decision that needs to be made',
+        required: true,
+      },
+      {
+        name: 'constraints',
+        description: 'Constraints that impact the decision',
+        required: false,
+      },
+      {
+        name: 'options',
+        description: 'Options being considered',
+        required: false,
+      },
+    ],
+  },
+};
+
+/**
+ * Template implementation functions.
+ * Each function takes a record of argument values and returns a prompt result.
+ */
+export const PROMPT_TEMPLATES: Record<string, (args: Record<string, string>) => PromptResult> = {
+  'bug-analysis': (args) => ({
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `# Bug Analysis Process
+
+1. **Understand the reported behavior**
+   - Bug behavior: ${args.bug_behavior || 'N/A'}
+   - Reproduction steps: ${args.reproduction_steps || 'N/A'}
+
+2. **Identify expected behavior**
+   - Expected behavior: ${args.expected_behavior || 'N/A'}
+
+3. **Isolate affected components**
+   - Affected components: ${args.affected_components || 'N/A'}
+
+4. **Form hypotheses**
+   - What are potential root causes? List hypotheses in priority order.
+
+5. **Test hypotheses**
+   - How can we validate each hypothesis?
+   - What experiments or tests will help confirm the cause?
+
+6. **Propose fix**
+   - Once cause is identified, what's the recommended fix?
+   - What side effects might this fix have?
+   - How can we verify the fix works?`,
+        },
+      },
+    ],
+  }),
+  'feature-planning': (args) => ({
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `# Feature Planning Process
+
+1. **Feature Requirements**
+   - Problem statement: ${args.problem_statement || 'N/A'}
+   - Target users: ${args.target_users || 'N/A'}
+   - Success criteria: ${args.success_criteria || 'N/A'}
+
+2. **Architectural Considerations**
+   - Affected components: ${args.affected_components || 'N/A'}
+   - What new components might be needed?
+   - Are there any API changes required?
+
+3. **Implementation Strategy**
+   - Break down the feature into implementation tasks
+   - Identify dependencies between tasks
+   - Estimate complexity and effort
+   - Plan an implementation sequence
+
+4. **Testing Strategy**
+   - What unit tests will be needed?
+   - What integration tests will be needed?
+   - How will we validate user requirements are met?
+
+5. **Risks and Mitigations**
+   - What technical risks exist?
+   - What product/user risks exist?
+   - How can we mitigate each risk?
+
+6. **Acceptance Criteria**
+   - Define clear criteria for when this feature is complete
+   - Include performance and quality expectations`,
+        },
+      },
+    ],
+  }),
+  'code-review': (args) => ({
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `# Code Review Template
+
+1. **Code to Review**
+\`\`\`${args.language || ''}
+${args.code || ''}
+\`\`\`
+
+2. **Requirements**
+${args.requirements || 'No specific requirements provided.'}
+
+3. **Functionality Review**
+   - Does the code correctly implement the requirements?
+   - Are edge cases handled appropriately?
+   - Is error handling sufficient and appropriate?
+
+4. **Code Quality Review**
+   - Is the code well-structured and maintainable?
+   - Are functions/methods single-purpose and reasonably sized?
+   - Are variable/function names clear and descriptive?
+   - Is there adequate documentation where needed?
+
+5. **Performance Review**
+   - Are there any potential performance issues?
+   - Are algorithms and data structures appropriate?
+   - Are there any unnecessary computations or operations?
+
+6. **Security Review**
+   - Are there any security vulnerabilities?
+   - Is user input validated and sanitized?
+   - Are sensitive operations properly secured?
+
+7. **Testing Review**
+   - Is test coverage adequate?
+   - Do tests cover edge cases and error conditions?
+   - Are tests clear and maintainable?
+
+8. **Summary and Recommendations**
+   - Overall assessment
+   - Key issues to address (prioritized)
+   - Suggestions for improvement`,
+        },
+      },
+    ],
+  }),
+  'refactoring-plan': (args) => ({
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `# Refactoring Plan
+
+1. **Current Code Assessment**
+   - Current issues: ${args.current_issues || 'N/A'}
+   - Goals: ${args.goals || 'N/A'}
+   - What is working well and should be preserved?
+   - What metrics indicate refactoring is needed (complexity, duplication, etc.)?
+
+2. **Refactoring Goals**
+   - What specific improvements are we targeting?
+   - What measurable outcomes do we expect?
+
+3. **Risk Analysis**
+   - What functionality might be affected?
+   - What are the testing implications?
+   - What dependencies might be impacted?
+
+4. **Refactoring Strategy**
+   - Break down the refactoring into discrete steps
+   - Prioritize steps for maximum impact with minimum risk
+   - Plan for incremental testing between steps
+
+5. **Testing Approach**
+   - How will we verify behavior is preserved?
+   - What regression tests are needed?
+   - How will we validate improvements?
+
+6. **Implementation Plan**
+   - Sequence of changes
+   - Estimated effort
+   - Verification points`,
+        },
+      },
+    ],
+  }),
+  'architecture-decision': (args) => ({
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `# Architecture Decision Record
+
+1. **Context**
+   - Decision context: ${args.decision_context || 'N/A'}
+   - Constraints: ${args.constraints || 'N/A'}
+   - Options: ${args.options || 'N/A'}
+
+2. **Options Considered**
+   - What alternatives have we identified?
+   - For each alternative:
+     - What are its key characteristics?
+     - What are its advantages?
+     - What are its disadvantages?
+     - What risks does it present?
+
+3. **Decision Criteria**
+   - What factors are most important for this decision?
+   - How do we weigh different concerns (performance, maintainability, etc.)?
+
+4. **Evaluation**
+   - How does each option perform against our criteria?
+   - What trade-offs does each option represent?
+
+5. **Decision**
+   - Which option do we select and why?
+   - What were the key factors in this decision?
+
+6. **Consequences**
+   - What are the implications of this decision?
+   - What becomes easier or harder as a result?
+   - What new constraints does this create?
+   - What follow-up decisions will be needed?`,
+        },
+      },
+    ],
+  }),
+};

--- a/src/prompts/types.ts
+++ b/src/prompts/types.ts
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Type definitions for MCP prompts.
+ *
+ * These types define the structure of prompts according to the Model Context Protocol (MCP).
+ * Prompts are reusable templates that can be discovered and used by MCP clients.
+ */
+
+/**
+ * Represents an argument/parameter for a prompt.
+ */
+export interface PromptArgument {
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+/**
+ * Represents a prompt as defined by the MCP.
+ */
+export interface Prompt {
+  name: string;
+  description: string;
+  arguments?: PromptArgument[];
+}
+
+/**
+ * Represents the content of a message in a prompt result.
+ */
+export interface PromptMessageContent {
+  type: 'text';
+  text: string;
+}
+
+/**
+ * Represents a message in a prompt result.
+ */
+export interface PromptMessage {
+  role: 'user' | 'assistant';
+  content: PromptMessageContent;
+}
+
+/**
+ * Represents the result of applying a prompt with arguments.
+ */
+export interface PromptResult {
+  messages: PromptMessage[];
+}

--- a/src/prompts/valueManager.ts
+++ b/src/prompts/valueManager.ts
@@ -7,6 +7,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { expandTildePath } from '../utils/paths.js';
 
 // Structure for stored prompt values
 interface StoredPromptValues {
@@ -27,7 +28,10 @@ export class PromptValueManager {
    * @param configDir The directory where configuration files are stored
    */
   constructor(configDir: string) {
-    this.valuesFilePath = path.join(configDir, 'prompt_values.json');
+    // Expand tilde in config directory path if present
+    const expandedConfigDir = expandTildePath(configDir);
+    this.valuesFilePath = path.join(expandedConfigDir, 'prompt_values.json');
+    console.error(`PromptValueManager using file path: ${this.valuesFilePath}`);
     this.values = this.loadValues();
   }
 

--- a/src/prompts/valueManager.ts
+++ b/src/prompts/valueManager.ts
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Manages storing and retrieving prompt argument values.
+ *
+ * This provides persistence for prompt arguments between sessions,
+ * allowing users to avoid repetitive entry of common values.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Structure for stored prompt values
+interface StoredPromptValues {
+  global: Record<string, string>;
+  prompts: Record<string, Record<string, string>>;
+}
+
+/**
+ * Manages the storage and retrieval of prompt argument values.
+ */
+export class PromptValueManager {
+  private valuesFilePath: string;
+  private values: StoredPromptValues;
+
+  /**
+   * Creates a new PromptValueManager.
+   *
+   * @param configDir The directory where configuration files are stored
+   */
+  constructor(configDir: string) {
+    this.valuesFilePath = path.join(configDir, 'prompt_values.json');
+    this.values = this.loadValues();
+  }
+
+  /**
+   * Loads the stored values from the JSON file.
+   * Creates a default file if it doesn't exist.
+   */
+  private loadValues(): StoredPromptValues {
+    try {
+      // Check if file exists
+      if (!fs.existsSync(this.valuesFilePath)) {
+        // Create default structure
+        const defaultValues: StoredPromptValues = {
+          global: {},
+          prompts: {},
+        };
+
+        // Write default file
+        fs.writeFileSync(this.valuesFilePath, JSON.stringify(defaultValues, null, 2));
+        return defaultValues;
+      }
+
+      // Read and parse the file
+      const fileContent = fs.readFileSync(this.valuesFilePath, 'utf8');
+      return JSON.parse(fileContent) as StoredPromptValues;
+    } catch (err) {
+      console.error('Error loading prompt values:', err);
+      // Return empty default structure on error
+      return { global: {}, prompts: {} };
+    }
+  }
+
+  /**
+   * Saves the current values to the JSON file.
+   */
+  private saveValues(): void {
+    try {
+      fs.writeFileSync(this.valuesFilePath, JSON.stringify(this.values, null, 2));
+    } catch (err) {
+      console.error('Error saving prompt values:', err);
+    }
+  }
+
+  /**
+   * Gets stored argument values for a prompt.
+   *
+   * @param promptName The name of the prompt
+   * @returns An object with stored argument values
+   */
+  getStoredValues(promptName: string): Record<string, string> {
+    // Start with global values
+    const result: Record<string, string> = { ...this.values.global };
+
+    // Add prompt-specific values if they exist
+    if (this.values.prompts[promptName]) {
+      Object.assign(result, this.values.prompts[promptName]);
+    }
+
+    return result;
+  }
+
+  /**
+   * Updates stored values with the new values provided.
+   *
+   * @param promptName The name of the prompt
+   * @param args The argument values to store
+   */
+  updateStoredValues(promptName: string, args: Record<string, string>): void {
+    // Extract global values (like working_directory)
+    if (args.working_directory) {
+      this.values.global.working_directory = args.working_directory;
+    }
+
+    // Ensure prompt entry exists
+    if (!this.values.prompts[promptName]) {
+      this.values.prompts[promptName] = {};
+    }
+
+    // Update prompt-specific values (excluding global ones)
+    const promptValues = this.values.prompts[promptName];
+    const globalKeys = Object.keys(this.values.global);
+
+    Object.entries(args).forEach(([key, value]) => {
+      // Skip global keys and empty values
+      if (!globalKeys.includes(key) && value.trim() !== '') {
+        promptValues[key] = value;
+      }
+    });
+
+    // Save updated values
+    this.saveValues();
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,6 +47,7 @@
 
 import process from 'node:process';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   CallToolRequestSchema,
@@ -88,6 +89,9 @@ interface CodeReasoningConfig {
   configDir?: string; // Directory for configuration files including stored prompt values
 }
 
+// Get the current file's directory path
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export const SERVER_CONFIG: Readonly<CodeReasoningConfig> = Object.freeze({
   maxThoughtLength: 20_000, // https://github.com/modelcontextprotocol/servers/issues/751
   timeoutMs: 60_000,
@@ -98,7 +102,7 @@ export const SERVER_CONFIG: Readonly<CodeReasoningConfig> = Object.freeze({
   // Prompt config with defaults
   promptsEnabled: true,
   customPromptsDir: undefined, // No custom prompts directory by default
-  configDir: path.join(process.cwd(), 'config'), // Default config directory
+  configDir: path.join(__dirname, '..', 'config'), // Config directory relative to src folder
 });
 
 /* -------------------------------------------------------------------------- */

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,7 @@
  */
 
 import process from 'node:process';
+import path from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   CallToolRequestSchema,
@@ -84,6 +85,7 @@ interface CodeReasoningConfig {
   // Prompt-related configuration
   promptsEnabled: boolean;
   customPromptsDir?: string; // Directory for custom prompt templates
+  configDir?: string; // Directory for configuration files including stored prompt values
 }
 
 export const SERVER_CONFIG: Readonly<CodeReasoningConfig> = Object.freeze({
@@ -96,6 +98,7 @@ export const SERVER_CONFIG: Readonly<CodeReasoningConfig> = Object.freeze({
   // Prompt config with defaults
   promptsEnabled: true,
   customPromptsDir: undefined, // No custom prompts directory by default
+  configDir: path.join(process.cwd(), 'config'), // Default config directory
 });
 
 /* -------------------------------------------------------------------------- */
@@ -453,7 +456,7 @@ export async function runServer(debugFlag = false): Promise<void> {
   // Initialize prompt manager if enabled
   let promptManager: PromptManager | undefined;
   if (config.promptsEnabled) {
-    promptManager = new PromptManager();
+    promptManager = new PromptManager(config.configDir);
     console.error('Prompts capability enabled');
 
     // Load custom prompts if configured

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -8,20 +8,39 @@
 import * as path from 'path';
 import * as os from 'os';
 
+import * as fs from 'fs';
+
 /**
  * Expands the tilde (~) character in a file path to the user's home directory.
  * This is useful for converting shell-like paths to absolute paths.
  *
  * @param filePath The file path to expand
+ * @param createDir Whether to create the directory if it doesn't exist
  * @returns The expanded file path
  *
  * @example
  * // Returns '/home/user/documents' on Linux/Mac or 'C:\Users\user\documents' on Windows
  * expandTildePath('~/documents');
  */
-export function expandTildePath(filePath: string): string {
+export function expandTildePath(filePath: string, createDir = false): string {
+  let expandedPath = filePath;
+
+  // Expand tilde if present
   if (filePath && (filePath.startsWith('~/') || filePath === '~')) {
-    return path.join(os.homedir(), filePath.slice(1));
+    expandedPath = path.join(os.homedir(), filePath.slice(1));
   }
-  return filePath;
+
+  // Create directory if requested and it doesn't exist
+  if (createDir && expandedPath) {
+    try {
+      if (!fs.existsSync(expandedPath)) {
+        fs.mkdirSync(expandedPath, { recursive: true });
+        console.error(`Created directory: ${expandedPath}`);
+      }
+    } catch (err) {
+      console.error(`Failed to create directory: ${expandedPath}`, err);
+    }
+  }
+
+  return expandedPath;
 }

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Path utility functions
+ *
+ * This file contains utility functions for working with file paths,
+ * such as expanding tilde characters in paths.
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Expands the tilde (~) character in a file path to the user's home directory.
+ * This is useful for converting shell-like paths to absolute paths.
+ *
+ * @param filePath The file path to expand
+ * @returns The expanded file path
+ *
+ * @example
+ * // Returns '/home/user/documents' on Linux/Mac or 'C:\Users\user\documents' on Windows
+ * expandTildePath('~/documents');
+ */
+export function expandTildePath(filePath: string): string {
+  if (filePath && (filePath.startsWith('~/') || filePath === '~')) {
+    return path.join(os.homedir(), filePath.slice(1));
+  }
+  return filePath;
+}


### PR DESCRIPTION
## Summary
- Adds MCP prompts capability for code reasoning with specialized templates for bug analysis, feature planning, code review, refactoring, and architecture decisions
- Implements prompt value persistence to save and reuse prompt arguments between sessions
- Adds comprehensive documentation and quickstart guide for using prompts with code-reasoning
- Adds working directory parameter and filesystem guidance to all prompts
- Improves configuration handling to prevent ENOENT errors

## Logical Feature Groups

This PR consists of several logical feature groups:

### 1. Core MCP Prompts Capability
- Initial implementation of prompt system with template definitions
- Integration with the server to handle MCP prompt requests
- Basic prompt argument handling

### 2. Prompt Value Persistence
- Added value manager to store and retrieve prompt values
- Configuration directory creation and handling
- Argument merging with stored values

### 3. Working Directory Integration
- Working directory parameter added to all prompts
- Filesystem guidance added to prompt templates
- Path utilities for handling file paths

### 4. Documentation
- Comprehensive documentation added for prompt features
- Configuration documentation updated

## Test plan
- Run the server with prompts enabled and confirm MCP client can list and use the prompts
- Verify that prompt values are persisted to the configuration directory
- Validate that prompt arguments are correctly validated and merged with stored values