### PR TITLE
fix: Redirect console.info logs to stderr to preserve MCP protocol

### DIFF
--- a/src/prompts/manager.ts
+++ b/src/prompts/manager.ts
@@ -45,18 +45,18 @@ export class PromptManager {
 
     this.ensureDirectoryExists(resolvedConfigDir, 'main config directory');
 
-    console.info(`Using config directory: ${resolvedConfigDir}`);
+    console.error(`Using config directory: ${resolvedConfigDir}`);
 
     this.initializeValueStorage(resolvedConfigDir);
 
-    console.info('PromptManager initialized with', Object.keys(this.prompts).length, 'prompts');
+    console.error('PromptManager initialized with', Object.keys(this.prompts).length, 'prompts');
   }
 
   private ensureDirectoryExists(directoryPath: string, description: string): void {
     try {
       const createdPath = fs.mkdirSync(directoryPath, { recursive: true });
       if (createdPath) {
-        console.info(`Created ${description}: ${directoryPath}`);
+        console.error(`Created ${description}: ${directoryPath}`);
       }
     } catch (err) {
       const error = err as Error;


### PR DESCRIPTION
The MCP protocol reserves stdout exclusively for JSON-RPC messages. Using console.info writes to stdout, which corrupts the JSON-RPC stream. This redirect prevents connection issues.