### PR TITLE
Fix strict stdio startup and add remote logging flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ See the [Prompts Guide](./docs/prompts.md) for details on using the prompt templ
 ## Command Line Options
 
 - `--debug`: Enable detailed logging
+- `--remote-logging`: Enable MCP `notifications/message` logging (disabled by default for strict stdio compatibility)
 - `--help` or `-h`: Show help information
 
 ## Key Features

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,11 +17,12 @@ This document provides detailed information about all configuration options avai
 
 The Code-Reasoning MCP Server supports the following command-line options:
 
-| Option         | Description                                   | Default  | Example                                       |
-| -------------- | --------------------------------------------- | -------- | --------------------------------------------- |
-| `--debug`      | Enable debug logging with more verbose output | `false`  | `code-reasoning --debug`                      |
-| `--help`, `-h` | Show help information                         | -        | `code-reasoning --help`                       |
-| `--config-dir` | Specify the configuration directory           | `config` | `code-reasoning --config-dir=/path/to/config` |
+| Option             | Description                                                     | Default  | Example                                       |
+| ------------------ | --------------------------------------------------------------- | -------- | --------------------------------------------- |
+| `--debug`          | Enable debug logging with more verbose output                   | `false`  | `code-reasoning --debug`                      |
+| `--remote-logging` | Enable MCP `notifications/message` logging for tolerant clients | `false`  | `code-reasoning --remote-logging`             |
+| `--help`, `-h`     | Show help information                                           | -        | `code-reasoning --help`                       |
+| `--config-dir`     | Specify the configuration directory                             | `config` | `code-reasoning --config-dir=/path/to/config` |
 
 ### Usage Examples
 
@@ -35,6 +36,12 @@ Debug mode:
 
 ```bash
 code-reasoning --debug
+```
+
+Enable remote MCP logging:
+
+```bash
+code-reasoning --remote-logging
 ```
 
 Help information:
@@ -131,6 +138,8 @@ The server uses the following streamlined approach:
 
 - All logs are written to stderr using `console.error()`
 - Debug logs are only shown when the `--debug` flag is enabled
+- Strict stdio compatibility is the default behavior
+- Remote MCP logging notifications are only emitted when `--remote-logging` is passed
 - The LogLevel enum is still used for compatibility but with simplified implementation
 - No log file rotation or custom log directories are supported
 

--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,15 @@
 // Import and run the server
 import('./src/server.js')
   .then(module => {
-    module.runServer();
+    const cliFlags = {
+      debug: process.argv.includes('--debug'),
+      remote_logging: process.argv.includes('--remote-logging'),
+    };
+
+    module.runServer({
+      debug: cliFlags.debug,
+      remoteLoggingEnabled: cliFlags.remote_logging,
+    });
   })
   .catch(error => {
     console.error('Error starting server:', error);

--- a/src/prompts/manager.ts
+++ b/src/prompts/manager.ts
@@ -216,8 +216,7 @@ export class PromptManager {
 
     const filteredStoredValues: Record<string, string> = {};
     Object.entries(storedValues).forEach(([key, value]) => {
-      const isGlobalKey = Object.prototype.hasOwnProperty.call(this.storedValues.global, key);
-      if (isGlobalKey && !validArgNames.has(key)) {
+      if (!validArgNames.has(key)) {
         return;
       }
       filteredStoredValues[key] = value;

--- a/src/server.ts
+++ b/src/server.ts
@@ -77,16 +77,28 @@ const MAX_THOUGHTS = 20;
 interface CodeReasoningConfig {
   debug: boolean;
   promptsEnabled: boolean;
+  remoteLoggingEnabled: boolean;
 }
 
 const DEFAULT_CONFIG: Readonly<CodeReasoningConfig> = Object.freeze({
   debug: false,
   promptsEnabled: true,
+  remoteLoggingEnabled: false,
 });
 
 const createConfig = (overrides: Partial<CodeReasoningConfig> = {}): CodeReasoningConfig => ({
   ...DEFAULT_CONFIG,
   ...overrides,
+});
+
+interface CliFlags {
+  debug: boolean;
+  remote_logging: boolean;
+}
+
+const parseCliFlags = (argv: string[]): CliFlags => ({
+  debug: argv.includes('--debug'),
+  remote_logging: argv.includes('--remote-logging'),
 });
 
 /* -------------------------------------------------------------------------- */
@@ -436,8 +448,13 @@ const createThoughtProcessor = (cfg: Readonly<CodeReasoningConfig>, logger: Serv
 /*                                BOOTSTRAP                                   */
 /* -------------------------------------------------------------------------- */
 
-export async function runServer(debugFlag = false): Promise<void> {
-  const config = createConfig(debugFlag ? { debug: true } : undefined);
+export async function runServer(
+  options: boolean | Partial<CodeReasoningConfig> = false
+): Promise<void> {
+  const config =
+    typeof options === 'boolean'
+      ? createConfig(options ? { debug: true } : undefined)
+      : createConfig(options);
 
   const serverMeta = { name: 'code-reasoning-server', version: '0.7.0' } as const;
 
@@ -455,6 +472,7 @@ export async function runServer(debugFlag = false): Promise<void> {
   logger.info('Server initialized', {
     version: serverMeta.version,
     promptsEnabled: config.promptsEnabled,
+    remoteLoggingEnabled: config.remoteLoggingEnabled,
   });
 
   // Register tool with MCP helper APIs
@@ -580,8 +598,12 @@ export async function runServer(debugFlag = false): Promise<void> {
 
   const transport = new StdioServerTransport();
   await mcp.connect(transport);
-  logger.enableRemoteLogging();
-  logger.notice('🚀 Code-Reasoning MCP Server ready.');
+  if (config.remoteLoggingEnabled) {
+    logger.enableRemoteLogging();
+    logger.notice('🚀 Code-Reasoning MCP Server ready.');
+  } else {
+    logger.info('Code-Reasoning MCP Server ready (stderr-only logging mode).');
+  }
 
   const shutdown = async (signal_name: string, exit_code = 0) => {
     logger.info('Shutdown signal received', { signal: signal_name, exit_code });
@@ -623,7 +645,11 @@ export async function runServer(debugFlag = false): Promise<void> {
 
 // Self-execute when run directly ------------------------------------------------
 if (import.meta.url === `file://${process.argv[1]}`) {
-  runServer(process.argv.includes('--debug')).catch(err => {
+  const cliFlags = parseCliFlags(process.argv);
+  runServer({
+    debug: cliFlags.debug,
+    remoteLoggingEnabled: cliFlags.remote_logging,
+  }).catch(err => {
     console.error('FATAL: failed to start', err);
     process.exit(1);
   });

--- a/test/mcp-regression.test.ts
+++ b/test/mcp-regression.test.ts
@@ -1,14 +1,19 @@
 import test, { before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import type { Readable } from 'node:stream';
+import { setTimeout as delay } from 'node:timers/promises';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import type { ContentBlock, PromptMessage } from '@modelcontextprotocol/sdk/types.js';
 
 const serverEntry = path.resolve(process.cwd(), 'dist', 'index.js');
+const testHomeDir = fs.mkdtempSync(path.join(process.cwd(), '.tmp-test-home-'));
+const serverEnv = { ...process.env, HOME: testHomeDir };
 
 if (!fs.existsSync(serverEntry)) {
   throw new Error(
@@ -20,6 +25,7 @@ const transport = new StdioClientTransport({
   command: process.execPath,
   args: [serverEntry],
   stderr: 'pipe',
+  env: serverEnv,
 });
 
 const client = new Client({
@@ -52,6 +58,72 @@ before(async () => {
 after(async () => {
   await client.close();
   await transport.close();
+  fs.rmSync(testHomeDir, { recursive: true, force: true });
+});
+
+test('does not emit stdout before MCP handshake', { concurrency: false }, async () => {
+  const child = spawn(process.execPath, [serverEntry], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: serverEnv,
+  });
+
+  let stdoutLog = '';
+  let stderrLog = '';
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', chunk => {
+    stdoutLog += String(chunk);
+  });
+  child.stderr?.on('data', chunk => {
+    stderrLog += String(chunk);
+  });
+
+  try {
+    await delay(250);
+  } finally {
+    child.kill('SIGTERM');
+    await once(child, 'exit');
+  }
+
+  assert.strictEqual(
+    stdoutLog.trim(),
+    '',
+    `Expected no stdout before handshake. stdout=${JSON.stringify(stdoutLog)} stderr=${JSON.stringify(stderrLog)}`
+  );
+});
+
+test('connects successfully with --remote-logging enabled', { concurrency: false }, async () => {
+  const remoteTransport = new StdioClientTransport({
+    command: process.execPath,
+    args: [serverEntry, '--remote-logging'],
+    stderr: 'pipe',
+    env: serverEnv,
+  });
+  const remoteClient = new Client({
+    name: 'mcp-regression-suite-remote-logging',
+    version: '0.1.0',
+  });
+
+  let remoteServerLog = '';
+  const remoteStderr = remoteTransport.stderr as Readable | null;
+  if (remoteStderr) {
+    remoteStderr.on('data', chunk => {
+      remoteServerLog += chunk.toString();
+    });
+  }
+
+  try {
+    await remoteClient.connect(remoteTransport);
+    const { tools } = await remoteClient.listTools();
+    const tool = tools.find(entry => entry.name === 'code-reasoning');
+    assert.ok(
+      tool,
+      `expected code-reasoning tool with --remote-logging. stderr=${remoteServerLog}`
+    );
+  } finally {
+    await remoteClient.close();
+    await remoteTransport.close();
+  }
 });
 
 test('lists the code-reasoning tool', { concurrency: false }, async () => {

--- a/test/mcp-regression.test.ts
+++ b/test/mcp-regression.test.ts
@@ -66,6 +66,7 @@ test('does not emit stdout before MCP handshake', { concurrency: false }, async 
     stdio: ['pipe', 'pipe', 'pipe'],
     env: serverEnv,
   });
+  const childExit = once(child, 'exit');
 
   let stdoutLog = '';
   let stderrLog = '';
@@ -81,8 +82,10 @@ test('does not emit stdout before MCP handshake', { concurrency: false }, async 
   try {
     await delay(250);
   } finally {
-    child.kill('SIGTERM');
-    await once(child, 'exit');
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGTERM');
+    }
+    await childExit;
   }
 
   assert.strictEqual(


### PR DESCRIPTION
## Summary
- default startup now stays in strict stdio mode and does **not** emit MCP `notifications/message` logs unless explicitly enabled
- added a new `--remote-logging` CLI flag so users can opt into remote MCP logging when their client tolerates it
- made `runServer` accept structured config options to cleanly support the new startup behavior
- fixed prompt argument merging to drop any stored keys not declared by the target prompt
- documented the new CLI behavior in `README.md` and `docs/configuration.md`
- added regression tests for strict startup (no stdout before handshake) and for successful operation with `--remote-logging`

## Why This Change Is Necessary
Some MCP clients are strict about stdio protocol framing during startup. Remote logging over MCP notifications can introduce protocol messages at times that are not tolerated by strict clients, causing connection instability or startup failures.

This change makes strict compatibility the default by keeping startup logging on stderr only. Remote MCP logging remains available via `--remote-logging` for environments that want it.

The prompt manager fix is included because stale stored values for non-declared arguments could leak into prompt application and trigger avoidable validation errors.

## Validation
- Added `test/mcp-regression.test.ts` coverage for:
  - no stdout emission before handshake in default mode
  - successful tool discovery with `--remote-logging` enabled
